### PR TITLE
Bump Nagios Plugins to 2.3.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV NAGIOS_CORE_ARCHIVE    https://github.com/NagiosEnterprises/nagioscore/archi
 ENV NAGIOS_NRPE_VERSION    3.2.1
 ENV NAGIOS_NRPE_ARCHIVE    https://github.com/NagiosEnterprises/nrpe/archive/nrpe-${NAGIOS_NRPE_VERSION}.tar.gz
 
-ENV NAGIOS_PLUGINS_VERSION 2.2.1
+ENV NAGIOS_PLUGINS_VERSION 2.3.1
 ENV NAGIOS_PLUGINS_ARCHIVE https://nagios-plugins.org/download/nagios-plugins-${NAGIOS_PLUGINS_VERSION}.tar.gz
 
 # ---- environment variables

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Integrated Items
 
 * Nagios Core 4.4.5
-* Nagios Plugins 2.2.1
+* Nagios Plugins 2.3.1
 * NRPE 3.2.1
 
 


### PR DESCRIPTION
Nagios Plugins 2.3.0 have been released on `2019-12-04`
- https://nagios-plugins.org/nagios-plugins-2-3-0-released/

Nagios Plugins 2.3.1 have been released on `2019-12-09`
- https://nagios-plugins.org/nagios-plugins-2-3-1-released/

But it looks like still having some bugs need to be fixed
- https://github.com/nagios-plugins/nagios-plugins/pull/502
- https://github.com/nagios-plugins/nagios-plugins/pull/503

So let's wait for `nagios-plugins-2.3.2` :mag: