### PR TITLE
Bump Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Ubuntu 16.04 is going to be retired, we should move onto 18.04 instead.